### PR TITLE
Update runtime to GNOME 45

### DIFF
--- a/io.github.leonardschardijn.Chirurgien.json
+++ b/io.github.leonardschardijn.Chirurgien.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.leonardschardijn.Chirurgien",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
+    "runtime-version" : "45",
     "sdk" : "org.gnome.Sdk",
     "command" : "chirurgien",
     "finish-args" : [


### PR DESCRIPTION
The app is now flagged as 'unsupported' in GNOME Software since it uses an outdated runtime;

![Screenshot from 2023-11-13 08-54-03](https://github.com/flathub/io.github.leonardschardijn.Chirurgien/assets/33983090/805978e0-8b7a-470a-9dec-d9cb5f65c1af)
